### PR TITLE
Discover > Category 항목과 Episode 리스트가 함께 스크롤 되도록 수정

### DIFF
--- a/app/src/main/java/com/august/jetcaster/ui/home/Home.kt
+++ b/app/src/main/java/com/august/jetcaster/ui/home/Home.kt
@@ -61,7 +61,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.august.jetcaster.R
 import com.august.jetcaster.data.PodcastWithExtraInfo
 import com.august.jetcaster.ui.home.discover.Discover

--- a/app/src/main/java/com/august/jetcaster/ui/home/category/PodcastCategory.kt
+++ b/app/src/main/java/com/august/jetcaster/ui/home/category/PodcastCategory.kt
@@ -88,7 +88,7 @@ import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 
 @Composable
-fun PodcastCategory(
+fun PodcastCategoryAndEpisodes(
     categoryId: Long,
     navigateToPlayer: (String) -> Unit,
     modifier: Modifier = Modifier
@@ -109,7 +109,7 @@ fun PodcastCategory(
     val viewState by viewModel.state.collectAsStateWithLifecycle()
 
     Column(modifier = modifier) {
-        EpisodeList(
+        CategoryAndEpisodesList(
             viewState.episodes,
             viewState.topPodcasts,
             navigateToPlayer,
@@ -118,20 +118,11 @@ fun PodcastCategory(
     }
 }
 
+/**
+ * List of categories and its corresponding episodes
+ */
 @Composable
-private fun CategoryPodcasts(
-    topPodcasts: List<PodcastWithExtraInfo>,
-    onTogglePodcastFollowed: (String) -> Unit,
-) {
-    CategoryPodcastRow(
-        podcasts = topPodcasts,
-        onTogglePodcastFollowed = onTogglePodcastFollowed,
-        modifier = Modifier.fillMaxWidth()
-    )
-}
-
-@Composable
-private fun EpisodeList(
+private fun CategoryAndEpisodesList(
     episodes: List<EpisodeToPodcast>,
     topPodcasts: List<PodcastWithExtraInfo>,
     navigateToPlayer: (String) -> Unit,
@@ -154,6 +145,18 @@ private fun EpisodeList(
             )
         }
     }
+}
+
+@Composable
+private fun CategoryPodcasts(
+    topPodcasts: List<PodcastWithExtraInfo>,
+    onTogglePodcastFollowed: (String) -> Unit,
+) {
+    CategoryPodcastRow(
+        podcasts = topPodcasts,
+        onTogglePodcastFollowed = onTogglePodcastFollowed,
+        modifier = Modifier.fillMaxWidth()
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/august/jetcaster/ui/home/category/PodcastCategory.kt
+++ b/app/src/main/java/com/august/jetcaster/ui/home/category/PodcastCategory.kt
@@ -112,19 +112,23 @@ fun PodcastCategory(
      * TODO: reset scroll position when category changes
      */
     Column(modifier = modifier) {
-        CategoryPodcasts(viewState.topPodcasts, viewModel)
-        EpisodeList(viewState.episodes, navigateToPlayer)
+        EpisodeList(
+            viewState.episodes,
+            viewState.topPodcasts,
+            navigateToPlayer,
+            viewModel::onTogglePodcastFollowed
+        )
     }
 }
 
 @Composable
 private fun CategoryPodcasts(
     topPodcasts: List<PodcastWithExtraInfo>,
-    viewModel: PodcastCategoryViewModel
+    onTogglePodcastFollowed: (String) -> Unit,
 ) {
     CategoryPodcastRow(
         podcasts = topPodcasts,
-        onTogglePodcastFollowed = viewModel::onTogglePodcastFollowed,
+        onTogglePodcastFollowed = onTogglePodcastFollowed,
         modifier = Modifier.fillMaxWidth()
     )
 }
@@ -132,12 +136,17 @@ private fun CategoryPodcasts(
 @Composable
 private fun EpisodeList(
     episodes: List<EpisodeToPodcast>,
-    navigateToPlayer: (String) -> Unit
+    topPodcasts: List<PodcastWithExtraInfo>,
+    navigateToPlayer: (String) -> Unit,
+    onTogglePodcastFollowed: (String) -> Unit,
 ) {
     LazyColumn(
         contentPadding = PaddingValues(0.dp),
         verticalArrangement = Arrangement.Center
     ) {
+        item {
+            CategoryPodcasts(topPodcasts, onTogglePodcastFollowed)
+        }
 
         items(episodes, key = { it.episode.uri }) { item ->
             EpisodeListItem(

--- a/app/src/main/java/com/august/jetcaster/ui/home/category/PodcastCategory.kt
+++ b/app/src/main/java/com/august/jetcaster/ui/home/category/PodcastCategory.kt
@@ -31,15 +31,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
-import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.LocalContentAlpha
@@ -47,17 +43,14 @@ import androidx.compose.material.LocalContentColor
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowUpward
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PlaylistAdd
 import androidx.compose.material.icons.rounded.PlayCircleFilled
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -91,7 +84,6 @@ import com.august.jetcaster.ui.theme.Keyline1
 import com.august.jetcaster.util.ToggleFollowPodcastIconButton
 import com.august.jetcaster.util.findActivity
 import dagger.hilt.android.EntryPointAccessors
-import kotlinx.coroutines.launch
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 
@@ -115,9 +107,6 @@ fun PodcastCategory(
         factory = PodcastCategoryViewModel.provideFactory(factory, categoryId)
     )
     val viewState by viewModel.state.collectAsStateWithLifecycle()
-    val lazyListState = rememberLazyListState()
-    val firstVisibleItemIndex by remember { derivedStateOf { lazyListState.firstVisibleItemIndex } }
-    val scope = rememberCoroutineScope()
 
     Column(modifier = modifier) {
         Box(contentAlignment = Alignment.BottomEnd) {
@@ -126,18 +115,7 @@ fun PodcastCategory(
                 viewState.topPodcasts,
                 navigateToPlayer,
                 viewModel::onTogglePodcastFollowed,
-                lazyListState = lazyListState
             )
-
-            if (lazyListState.isScrollInProgress.not() && firstVisibleItemIndex != 0) {
-                FloatingActionButton(
-                    modifier = Modifier.padding(24.dp),
-                    onClick = { scope.launch { lazyListState.scrollToItem(0) } },
-                    shape = CircleShape,
-                ) {
-                    Icon(Icons.Filled.ArrowUpward, "Upward Arrow Icon")
-                }
-            }
         }
     }
 }
@@ -160,11 +138,9 @@ private fun EpisodeList(
     topPodcasts: List<PodcastWithExtraInfo>,
     navigateToPlayer: (String) -> Unit,
     onTogglePodcastFollowed: (String) -> Unit,
-    lazyListState: LazyListState,
 ) {
     LazyColumn(
         contentPadding = PaddingValues(0.dp),
-        state = lazyListState,
         verticalArrangement = Arrangement.Center
     ) {
         item {

--- a/app/src/main/java/com/august/jetcaster/ui/home/category/PodcastCategory.kt
+++ b/app/src/main/java/com/august/jetcaster/ui/home/category/PodcastCategory.kt
@@ -109,14 +109,12 @@ fun PodcastCategory(
     val viewState by viewModel.state.collectAsStateWithLifecycle()
 
     Column(modifier = modifier) {
-        Box(contentAlignment = Alignment.BottomEnd) {
-            EpisodeList(
-                viewState.episodes,
-                viewState.topPodcasts,
-                navigateToPlayer,
-                viewModel::onTogglePodcastFollowed,
-            )
-        }
+        EpisodeList(
+            viewState.episodes,
+            viewState.topPodcasts,
+            navigateToPlayer,
+            viewModel::onTogglePodcastFollowed,
+        )
     }
 }
 

--- a/app/src/main/java/com/august/jetcaster/ui/home/discover/Discover.kt
+++ b/app/src/main/java/com/august/jetcaster/ui/home/discover/Discover.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.august.jetcaster.data.Category
-import com.august.jetcaster.ui.home.category.PodcastCategory
+import com.august.jetcaster.ui.home.category.PodcastCategoryAndEpisodes
 import com.august.jetcaster.ui.theme.Keyline1
 
 @Composable
@@ -71,7 +71,7 @@ fun Discover(
                 /**
                  * TODO, need to think about how this will scroll within the outer VerticalScroller
                  */
-                PodcastCategory(
+                PodcastCategoryAndEpisodes(
                     categoryId = category.id,
                     navigateToPlayer = navigateToPlayer,
                     modifier = Modifier.fillMaxSize()


### PR DESCRIPTION
- 카테고리와 에피소드 리스트가 함께 스크롤 되도록 코드를 수정합니다. 
- scroll to top 을 처음에 floating action button 으로 구현해보려 했는데, 에피소드 리스트 아이템에 클릭되는 부분들이 가려지는 것 같아서 일단 빼두었습니다. 
- AppBar 를 클릭할때 scrollToTop 하도록 하는건 어떨까도 고민했는데, lazyListState 에 대한 hoisting 이 너무 여러 컴포저블에 걸쳐서 일어나는 것 같아서 좋은 방법이 있을지 고민이 필요해 보입니다. (혹시 아이디어 있으시면 말씀 부탁드려요) 